### PR TITLE
feat: フロントエンド基盤 - 共通レイアウトとナビゲーション (Issue #16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.20.0",
+        "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
@@ -1785,6 +1787,48 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz",
+      "integrity": "sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
@@ -2042,6 +2086,76 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -2160,6 +2274,87 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2345,6 +2540,78 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2585,6 +2852,24 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -11325,6 +11610,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "dependencies": {
     "@prisma/client": "^5.20.0",
+    "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/src/components/layout/__tests__/header.test.tsx
+++ b/src/components/layout/__tests__/header.test.tsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Header } from '../header'
+import { useAuth } from '@/hooks/use-auth'
+
+// useAuthフックをモック
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+describe('Header', () => {
+  const mockLogout = vi.fn()
+  const mockOnMenuClick = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('ロゴが正しく表示される', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: {
+        id: 1,
+        name: '山田太郎',
+        email: 'yamada@example.com',
+        role: 'sales',
+        department: '営業部',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    render(<Header />)
+    expect(screen.getByText('営業日報システム')).toBeInTheDocument()
+  })
+
+  it('ユーザー名が表示される（デスクトップ）', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: {
+        id: 1,
+        name: '山田太郎',
+        email: 'yamada@example.com',
+        role: 'sales',
+        department: '営業部',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    render(<Header />)
+    expect(screen.getByText('山田太郎')).toBeInTheDocument()
+  })
+
+  it('ユーザーのイニシャルがアバターに表示される', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: {
+        id: 1,
+        name: '山田太郎',
+        email: 'yamada@example.com',
+        role: 'sales',
+        department: '営業部',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    render(<Header />)
+    // 日本語名の場合、最初の1文字が表示される
+    expect(screen.getByText('山')).toBeInTheDocument()
+  })
+
+  it('ドロップダウンメニューを開いて、ユーザー情報が表示される', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useAuth).mockReturnValue({
+      user: {
+        id: 1,
+        name: '山田太郎',
+        email: 'yamada@example.com',
+        role: 'sales',
+        department: '営業部',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    render(<Header />)
+
+    // ドロップダウンをクリック
+    const dropdownTrigger = screen.getByRole('button', { name: /山田太郎/i })
+    await user.click(dropdownTrigger)
+
+    // メニュー内のユーザー情報が表示される
+    await waitFor(() => {
+      expect(screen.getAllByText('yamada@example.com')[0]).toBeInTheDocument()
+      expect(screen.getByText('営業')).toBeInTheDocument()
+    })
+  })
+
+  it('上長ロールの場合、"上長"と表示される', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useAuth).mockReturnValue({
+      user: {
+        id: 2,
+        name: '佐藤花子',
+        email: 'sato@example.com',
+        role: 'manager',
+        department: '営業部',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    render(<Header />)
+
+    const dropdownTrigger = screen.getByRole('button', { name: /佐藤花子/i })
+    await user.click(dropdownTrigger)
+
+    await waitFor(() => {
+      expect(screen.getByText('上長')).toBeInTheDocument()
+    })
+  })
+
+  it('ログアウトボタンをクリックするとlogout関数が呼ばれる', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useAuth).mockReturnValue({
+      user: {
+        id: 1,
+        name: '山田太郎',
+        email: 'yamada@example.com',
+        role: 'sales',
+        department: '営業部',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    render(<Header />)
+
+    // ドロップダウンを開く
+    const dropdownTrigger = screen.getByRole('button', { name: /山田太郎/i })
+    await user.click(dropdownTrigger)
+
+    // ログアウトをクリック
+    const logoutButton = await screen.findByRole('menuitem', { name: /ログアウト/i })
+    await user.click(logoutButton)
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('モバイルメニューボタンをクリックするとonMenuClickが呼ばれる', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useAuth).mockReturnValue({
+      user: {
+        id: 1,
+        name: '山田太郎',
+        email: 'yamada@example.com',
+        role: 'sales',
+        department: '営業部',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    render(<Header onMenuClick={mockOnMenuClick} />)
+
+    const menuButton = screen.getByRole('button', { name: 'メニューを開く' })
+    await user.click(menuButton)
+
+    expect(mockOnMenuClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('ローディング中はユーザーメニューが表示されない', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    render(<Header />)
+
+    // ユーザー名が表示されていないことを確認
+    expect(screen.queryByText('山田太郎')).not.toBeInTheDocument()
+  })
+
+  it('未認証の場合はユーザーメニューが表示されない', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    render(<Header />)
+
+    // ユーザー名が表示されていないことを確認
+    expect(screen.queryByText('山田太郎')).not.toBeInTheDocument()
+  })
+
+  it('プロフィールリンクが正しいhrefを持つ', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useAuth).mockReturnValue({
+      user: {
+        id: 1,
+        name: '山田太郎',
+        email: 'yamada@example.com',
+        role: 'sales',
+        department: '営業部',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    render(<Header />)
+
+    const dropdownTrigger = screen.getByRole('button', { name: /山田太郎/i })
+    await user.click(dropdownTrigger)
+
+    const profileLink = await screen.findByRole('menuitem', { name: /プロフィール/i })
+    expect(profileLink).toHaveAttribute('href', '/profile')
+  })
+})

--- a/src/components/layout/__tests__/main-layout.test.tsx
+++ b/src/components/layout/__tests__/main-layout.test.tsx
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MainLayout } from '../main-layout'
+import { useAuth } from '@/hooks/use-auth'
+import { usePathname } from 'next/navigation'
+
+// useAuthフックをモック
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+// next/navigationをモック
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+}))
+
+describe('MainLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(usePathname).mockReturnValue('/dashboard')
+    vi.mocked(useAuth).mockReturnValue({
+      user: {
+        id: 1,
+        name: '山田太郎',
+        email: 'yamada@example.com',
+        role: 'sales',
+        department: '営業部',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+    })
+  })
+
+  it('子要素が正しくレンダリングされる', () => {
+    render(
+      <MainLayout>
+        <div>テストコンテンツ</div>
+      </MainLayout>
+    )
+
+    expect(screen.getByText('テストコンテンツ')).toBeInTheDocument()
+  })
+
+  it('ヘッダーが表示される', () => {
+    render(
+      <MainLayout>
+        <div>コンテンツ</div>
+      </MainLayout>
+    )
+
+    expect(screen.getByRole('banner')).toBeInTheDocument()
+    expect(screen.getByText('営業日報システム')).toBeInTheDocument()
+  })
+
+  it('ナビゲーションが表示される（デスクトップ）', () => {
+    render(
+      <MainLayout>
+        <div>コンテンツ</div>
+      </MainLayout>
+    )
+
+    const nav = screen.getByRole('navigation')
+    expect(nav).toBeInTheDocument()
+    expect(within(nav).getByText('ダッシュボード')).toBeInTheDocument()
+  })
+
+  it('メインコンテンツエリアが表示される', () => {
+    render(
+      <MainLayout>
+        <div data-testid="content">メインコンテンツ</div>
+      </MainLayout>
+    )
+
+    const main = screen.getByRole('main')
+    expect(main).toBeInTheDocument()
+    expect(within(main).getByTestId('content')).toBeInTheDocument()
+  })
+
+  it('maxWidth=trueの場合、コンテンツに最大幅が適用される', () => {
+    render(
+      <MainLayout maxWidth={true}>
+        <div>コンテンツ</div>
+      </MainLayout>
+    )
+
+    const main = screen.getByRole('main')
+    const container = main.firstChild as HTMLElement
+    expect(container.className).toContain('max-w-7xl')
+  })
+
+  it('maxWidth=falseの場合、コンテンツに最大幅が適用されない', () => {
+    render(
+      <MainLayout maxWidth={false}>
+        <div>コンテンツ</div>
+      </MainLayout>
+    )
+
+    const main = screen.getByRole('main')
+    const container = main.firstChild as HTMLElement
+    expect(container.className).not.toContain('max-w-7xl')
+  })
+
+  it('デフォルトでmaxWidth=trueが適用される', () => {
+    render(
+      <MainLayout>
+        <div>コンテンツ</div>
+      </MainLayout>
+    )
+
+    const main = screen.getByRole('main')
+    const container = main.firstChild as HTMLElement
+    expect(container.className).toContain('max-w-7xl')
+  })
+
+  it('モバイルメニューボタンが表示される', () => {
+    render(
+      <MainLayout>
+        <div>コンテンツ</div>
+      </MainLayout>
+    )
+
+    expect(screen.getByRole('button', { name: 'メニューを開く' })).toBeInTheDocument()
+  })
+
+  it('モバイルメニューボタンをクリックするとモバイルメニューが開く', async () => {
+    const user = userEvent.setup()
+    render(
+      <MainLayout>
+        <div>コンテンツ</div>
+      </MainLayout>
+    )
+
+    const menuButton = screen.getByRole('button', { name: 'メニューを開く' })
+
+    // 初期状態ではモバイルナビゲーションが表示されていない
+    expect(screen.queryByLabelText('モバイルナビゲーション')).not.toBeInTheDocument()
+
+    await user.click(menuButton)
+
+    // モバイルナビゲーションが表示される
+    expect(screen.getByLabelText('モバイルナビゲーション')).toBeInTheDocument()
+  })
+
+  describe('レスポンシブ動作', () => {
+    it('デスクトップではサイドバーが表示される', () => {
+      render(
+        <MainLayout>
+          <div>コンテンツ</div>
+        </MainLayout>
+      )
+
+      const aside = document.querySelector('aside')
+      expect(aside).toBeInTheDocument()
+      expect(aside?.className).toContain('md:block')
+    })
+
+    it('モバイルではサイドバーが隠される', () => {
+      render(
+        <MainLayout>
+          <div>コンテンツ</div>
+        </MainLayout>
+      )
+
+      const aside = document.querySelector('aside')
+      expect(aside?.className).toContain('hidden')
+    })
+  })
+
+  describe('複数の子要素', () => {
+    it('複数の子要素が正しくレンダリングされる', () => {
+      render(
+        <MainLayout>
+          <h1>タイトル</h1>
+          <p>段落1</p>
+          <p>段落2</p>
+        </MainLayout>
+      )
+
+      expect(screen.getByText('タイトル')).toBeInTheDocument()
+      expect(screen.getByText('段落1')).toBeInTheDocument()
+      expect(screen.getByText('段落2')).toBeInTheDocument()
+    })
+
+    it('ネストされたコンポーネントが正しくレンダリングされる', () => {
+      const NestedComponent = () => (
+        <div>
+          <h2>ネストされたタイトル</h2>
+          <div>ネストされたコンテンツ</div>
+        </div>
+      )
+
+      render(
+        <MainLayout>
+          <NestedComponent />
+        </MainLayout>
+      )
+
+      expect(screen.getByText('ネストされたタイトル')).toBeInTheDocument()
+      expect(screen.getByText('ネストされたコンテンツ')).toBeInTheDocument()
+    })
+  })
+
+  describe('ユーザーロールの統合', () => {
+    it('営業ユーザーの場合、ユーザー管理メニューが表示されない', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          id: 1,
+          name: '山田太郎',
+          email: 'yamada@example.com',
+          role: 'sales',
+          department: '営業部',
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+
+      render(
+        <MainLayout>
+          <div>コンテンツ</div>
+        </MainLayout>
+      )
+
+      const nav = screen.getByRole('navigation')
+      expect(within(nav).queryByText('ユーザー管理')).not.toBeInTheDocument()
+    })
+
+    it('上長ユーザーの場合、ユーザー管理メニューが表示される', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          id: 2,
+          name: '佐藤花子',
+          email: 'sato@example.com',
+          role: 'manager',
+          department: '営業部',
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+
+      render(
+        <MainLayout>
+          <div>コンテンツ</div>
+        </MainLayout>
+      )
+
+      const nav = screen.getByRole('navigation')
+      expect(within(nav).getByText('ユーザー管理')).toBeInTheDocument()
+    })
+  })
+
+  describe('構造とレイアウト', () => {
+    it('正しい階層構造でレンダリングされる', () => {
+      render(
+        <MainLayout>
+          <div data-testid="content">コンテンツ</div>
+        </MainLayout>
+      )
+
+      // ヘッダー > サイドバー/メイン の構造を確認
+      const header = screen.getByRole('banner')
+      const main = screen.getByRole('main')
+      const aside = document.querySelector('aside')
+
+      expect(header).toBeInTheDocument()
+      expect(aside).toBeInTheDocument()
+      expect(main).toBeInTheDocument()
+    })
+
+    it('min-h-screenクラスが適用されている', () => {
+      const { container } = render(
+        <MainLayout>
+          <div>コンテンツ</div>
+        </MainLayout>
+      )
+
+      const layoutRoot = container.firstChild as HTMLElement
+      expect(layoutRoot.className).toContain('min-h-screen')
+    })
+  })
+})

--- a/src/components/layout/__tests__/navigation.test.tsx
+++ b/src/components/layout/__tests__/navigation.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Navigation } from '../navigation'
+import { useAuth } from '@/hooks/use-auth'
+import { usePathname } from 'next/navigation'
+
+// useAuthフックをモック
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}))
+
+// next/navigationをモック
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+}))
+
+describe('Navigation', () => {
+  const mockOnNavigate = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(usePathname).mockReturnValue('/dashboard')
+  })
+
+  describe('営業ユーザー', () => {
+    beforeEach(() => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          id: 1,
+          name: '山田太郎',
+          email: 'yamada@example.com',
+          role: 'sales',
+          department: '営業部',
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+    })
+
+    it('営業ユーザー用のメニュー項目が表示される', () => {
+      render(<Navigation />)
+
+      expect(screen.getByText('ダッシュボード')).toBeInTheDocument()
+      expect(screen.getByText('日報一覧')).toBeInTheDocument()
+      expect(screen.getByText('日報作成')).toBeInTheDocument()
+      expect(screen.getByText('顧客一覧')).toBeInTheDocument()
+      expect(screen.getByText('顧客登録')).toBeInTheDocument()
+    })
+
+    it('営業ユーザーにはユーザー管理メニューが表示されない', () => {
+      render(<Navigation />)
+
+      expect(screen.queryByText('ユーザー管理')).not.toBeInTheDocument()
+    })
+
+    it('各メニュー項目が正しいリンクを持つ', () => {
+      render(<Navigation />)
+
+      expect(screen.getByRole('link', { name: /ダッシュボード/i })).toHaveAttribute(
+        'href',
+        '/dashboard'
+      )
+      expect(screen.getByRole('link', { name: /日報一覧/i })).toHaveAttribute(
+        'href',
+        '/daily-reports'
+      )
+      expect(screen.getByRole('link', { name: /日報作成/i })).toHaveAttribute(
+        'href',
+        '/daily-reports/new'
+      )
+      expect(screen.getByRole('link', { name: /顧客一覧/i })).toHaveAttribute(
+        'href',
+        '/customers'
+      )
+      expect(screen.getByRole('link', { name: /顧客登録/i })).toHaveAttribute(
+        'href',
+        '/customers/new'
+      )
+    })
+
+    it('現在のパスに対応するメニュー項目がアクティブになる', () => {
+      vi.mocked(usePathname).mockReturnValue('/dashboard')
+      render(<Navigation />)
+
+      const activeLink = screen.getByRole('link', { name: /ダッシュボード/i })
+      expect(activeLink).toHaveAttribute('aria-current', 'page')
+      expect(activeLink.className).toContain('bg-primary')
+    })
+
+    it('サブパスでもアクティブ判定される', () => {
+      vi.mocked(usePathname).mockReturnValue('/daily-reports/123')
+      render(<Navigation />)
+
+      const activeLink = screen.getByRole('link', { name: /日報一覧/i })
+      expect(activeLink).toHaveAttribute('aria-current', 'page')
+    })
+  })
+
+  describe('上長ユーザー', () => {
+    beforeEach(() => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          id: 2,
+          name: '佐藤花子',
+          email: 'sato@example.com',
+          role: 'manager',
+          department: '営業部',
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+    })
+
+    it('上長ユーザー用のすべてのメニュー項目が表示される', () => {
+      render(<Navigation />)
+
+      expect(screen.getByText('ダッシュボード')).toBeInTheDocument()
+      expect(screen.getByText('日報一覧')).toBeInTheDocument()
+      expect(screen.getByText('日報作成')).toBeInTheDocument()
+      expect(screen.getByText('顧客一覧')).toBeInTheDocument()
+      expect(screen.getByText('顧客登録')).toBeInTheDocument()
+      expect(screen.getByText('ユーザー管理')).toBeInTheDocument()
+    })
+
+    it('ユーザー管理メニューが正しいリンクを持つ', () => {
+      render(<Navigation />)
+
+      expect(screen.getByRole('link', { name: /ユーザー管理/i })).toHaveAttribute(
+        'href',
+        '/users'
+      )
+    })
+  })
+
+  describe('モバイルモード', () => {
+    beforeEach(() => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          id: 1,
+          name: '山田太郎',
+          email: 'yamada@example.com',
+          role: 'sales',
+          department: '営業部',
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+    })
+
+    it('モバイルモードで正しくレンダリングされる', () => {
+      render(<Navigation isMobile />)
+
+      expect(screen.getByText('ダッシュボード')).toBeInTheDocument()
+    })
+
+    it('メニュー項目をクリックするとonNavigateが呼ばれる', async () => {
+      const user = userEvent.setup()
+      render(<Navigation isMobile onNavigate={mockOnNavigate} />)
+
+      const dashboardLink = screen.getByRole('link', { name: /ダッシュボード/i })
+      await user.click(dashboardLink)
+
+      expect(mockOnNavigate).toHaveBeenCalledTimes(1)
+    })
+
+    it('複数のメニュー項目をクリックすると、それぞれonNavigateが呼ばれる', async () => {
+      const user = userEvent.setup()
+      render(<Navigation isMobile onNavigate={mockOnNavigate} />)
+
+      await user.click(screen.getByRole('link', { name: /ダッシュボード/i }))
+      await user.click(screen.getByRole('link', { name: /日報一覧/i }))
+
+      expect(mockOnNavigate).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('ユーザーが未認証', () => {
+    beforeEach(() => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+    })
+
+    it('ユーザー管理メニューが表示されない（roleがnull）', () => {
+      render(<Navigation />)
+
+      expect(screen.queryByText('ユーザー管理')).not.toBeInTheDocument()
+    })
+
+    it('基本メニューは表示される', () => {
+      render(<Navigation />)
+
+      expect(screen.getByText('ダッシュボード')).toBeInTheDocument()
+      expect(screen.getByText('日報一覧')).toBeInTheDocument()
+    })
+  })
+
+  describe('アクセシビリティ', () => {
+    beforeEach(() => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          id: 1,
+          name: '山田太郎',
+          email: 'yamada@example.com',
+          role: 'sales',
+          department: '営業部',
+        },
+        isAuthenticated: true,
+        isLoading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+    })
+
+    it('navタグにaria-labelが設定されている', () => {
+      render(<Navigation />)
+
+      const nav = screen.getByRole('navigation')
+      expect(nav).toHaveAttribute('aria-label', 'メインナビゲーション')
+    })
+
+    it('アクティブなリンクにaria-current="page"が設定される', () => {
+      vi.mocked(usePathname).mockReturnValue('/customers')
+      render(<Navigation />)
+
+      const activeLink = screen.getByRole('link', { name: /顧客一覧/i })
+      expect(activeLink).toHaveAttribute('aria-current', 'page')
+    })
+  })
+})

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+/**
+ * ヘッダーコンポーネント
+ * ロゴ、ユーザー情報、ログアウトボタンを含むアプリケーションヘッダー
+ */
+
+import React, { useState } from 'react'
+import Link from 'next/link'
+import { Menu, LogOut, User as UserIcon } from 'lucide-react'
+import { useAuth } from '@/hooks/use-auth'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+
+export interface HeaderProps {
+  /** モバイルメニューのトグル関数 */
+  onMenuClick?: () => void
+}
+
+/**
+ * ユーザー名のイニシャルを取得
+ */
+function getInitials(name: string): string {
+  // 日本語の名前の場合、最初の1文字を返す
+  if (/[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(name)) {
+    return name.charAt(0)
+  }
+  // 英語の名前の場合、最初の2文字を返す
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+/**
+ * ヘッダーコンポーネント
+ */
+export function Header({ onMenuClick }: HeaderProps) {
+  const { user, logout, isLoading } = useAuth()
+  const [isLoggingOut, setIsLoggingOut] = useState(false)
+
+  const handleLogout = async () => {
+    try {
+      setIsLoggingOut(true)
+      await logout()
+    } catch (error) {
+      console.error('Logout failed:', error)
+      setIsLoggingOut(false)
+    }
+  }
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="container flex h-14 items-center">
+        {/* モバイルメニューボタン */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="mr-2 md:hidden"
+          onClick={onMenuClick}
+          aria-label="メニューを開く"
+        >
+          <Menu className="h-5 w-5" />
+        </Button>
+
+        {/* ロゴ */}
+        <div className="mr-4 flex">
+          <Link href="/dashboard" className="flex items-center space-x-2">
+            <span className="text-lg font-bold">営業日報システム</span>
+          </Link>
+        </div>
+
+        {/* スペーサー */}
+        <div className="flex flex-1" />
+
+        {/* ユーザーメニュー */}
+        {!isLoading && user && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                className="relative h-9 w-9 rounded-full md:h-auto md:w-auto md:rounded-md md:px-3"
+              >
+                <Avatar className="h-8 w-8 md:mr-2">
+                  <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
+                </Avatar>
+                <span className="hidden md:inline-block">{user.name}</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuLabel>
+                <div className="flex flex-col space-y-1">
+                  <p className="text-sm font-medium leading-none">{user.name}</p>
+                  <p className="text-xs leading-none text-muted-foreground">
+                    {user.email}
+                  </p>
+                  <p className="text-xs leading-none text-muted-foreground">
+                    {user.role === 'manager' ? '上長' : '営業'}
+                  </p>
+                </div>
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem asChild>
+                <Link href="/profile" className="cursor-pointer">
+                  <UserIcon className="mr-2 h-4 w-4" />
+                  プロフィール
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={handleLogout}
+                disabled={isLoggingOut}
+                className="cursor-pointer text-destructive focus:text-destructive"
+              >
+                <LogOut className="mr-2 h-4 w-4" />
+                {isLoggingOut ? 'ログアウト中...' : 'ログアウト'}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+    </header>
+  )
+}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,0 +1,8 @@
+export { Header } from './header'
+export type { HeaderProps } from './header'
+
+export { Navigation } from './navigation'
+export type { NavigationProps } from './navigation'
+
+export { MainLayout } from './main-layout'
+export type { MainLayoutProps } from './main-layout'

--- a/src/components/layout/main-layout.tsx
+++ b/src/components/layout/main-layout.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+/**
+ * メインレイアウトコンポーネント
+ * ヘッダー、ナビゲーション、コンテンツエリアを含むアプリケーションの基本レイアウト
+ */
+
+import React, { useState, useEffect } from 'react'
+import { Header } from './header'
+import { Navigation } from './navigation'
+import { cn } from '@/lib/utils'
+
+export interface MainLayoutProps {
+  /** コンテンツエリアに表示する要素 */
+  children: React.ReactNode
+  /** コンテナの最大幅を制限するかどうか */
+  maxWidth?: boolean
+}
+
+/**
+ * メインレイアウトコンポーネント
+ */
+export function MainLayout({ children, maxWidth = true }: MainLayoutProps) {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+
+  const handleMobileMenuToggle = () => {
+    setIsMobileMenuOpen((prev) => !prev)
+  }
+
+  const handleMobileMenuClose = () => {
+    setIsMobileMenuOpen(false)
+  }
+
+  // モバイルメニューが開いているときにbodyのスクロールを防ぐ
+  useEffect(() => {
+    if (isMobileMenuOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'unset'
+    }
+    return () => {
+      document.body.style.overflow = 'unset'
+    }
+  }, [isMobileMenuOpen])
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* ヘッダー */}
+      <Header onMenuClick={handleMobileMenuToggle} />
+
+      <div className="flex">
+        {/* デスクトップサイドバー */}
+        <aside className="hidden w-64 border-r bg-background md:block">
+          <div className="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto">
+            <Navigation />
+          </div>
+        </aside>
+
+        {/* モバイルメニュー */}
+        {isMobileMenuOpen && (
+          <>
+            {/* オーバーレイ */}
+            <div
+              className="fixed inset-0 z-40 bg-black/50 md:hidden"
+              onClick={handleMobileMenuClose}
+              aria-hidden="true"
+            />
+            {/* サイドバー */}
+            <aside
+              className="fixed left-0 top-14 z-50 h-[calc(100vh-3.5rem)] w-64 border-r bg-background md:hidden"
+              role="navigation"
+              aria-label="モバイルナビゲーション"
+            >
+              <div className="h-full overflow-y-auto">
+                <Navigation isMobile onNavigate={handleMobileMenuClose} />
+              </div>
+            </aside>
+          </>
+        )}
+
+        {/* メインコンテンツ */}
+        <main className="flex-1">
+          <div
+            className={cn(
+              'min-h-[calc(100vh-3.5rem)] p-4 md:p-6 lg:p-8',
+              maxWidth && 'mx-auto max-w-7xl'
+            )}
+          >
+            {children}
+          </div>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+/**
+ * ナビゲーションコンポーネント
+ * アプリケーションのメインナビゲーションメニュー
+ * ユーザーのロールに応じてメニュー項目を表示
+ */
+
+import React from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import {
+  LayoutDashboard,
+  FileText,
+  Users,
+  Settings,
+  ClipboardList,
+  UserPlus,
+} from 'lucide-react'
+import { useAuth } from '@/hooks/use-auth'
+import { cn } from '@/lib/utils'
+
+export interface NavigationProps {
+  /** モバイル表示かどうか */
+  isMobile?: boolean
+  /** メニューを閉じるコールバック（モバイル用） */
+  onNavigate?: () => void
+}
+
+interface NavItem {
+  href: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  roles?: ('sales' | 'manager')[]
+}
+
+const navItems: NavItem[] = [
+  {
+    href: '/dashboard',
+    label: 'ダッシュボード',
+    icon: LayoutDashboard,
+  },
+  {
+    href: '/daily-reports',
+    label: '日報一覧',
+    icon: FileText,
+  },
+  {
+    href: '/daily-reports/new',
+    label: '日報作成',
+    icon: ClipboardList,
+  },
+  {
+    href: '/customers',
+    label: '顧客一覧',
+    icon: Users,
+  },
+  {
+    href: '/customers/new',
+    label: '顧客登録',
+    icon: UserPlus,
+  },
+  {
+    href: '/users',
+    label: 'ユーザー管理',
+    icon: Settings,
+    roles: ['manager'],
+  },
+]
+
+/**
+ * ナビゲーションコンポーネント
+ */
+export function Navigation({ isMobile = false, onNavigate }: NavigationProps) {
+  const pathname = usePathname()
+  const { user } = useAuth()
+
+  // ユーザーのロールに基づいてメニュー項目をフィルタリング
+  const filteredNavItems = navItems.filter((item) => {
+    if (!item.roles) return true
+    return user?.role && item.roles.includes(user.role)
+  })
+
+  const handleClick = () => {
+    if (onNavigate) {
+      onNavigate()
+    }
+  }
+
+  return (
+    <nav
+      className={cn(
+        'space-y-1',
+        isMobile ? 'px-2 pb-4 pt-2' : 'px-2 py-4'
+      )}
+      aria-label="メインナビゲーション"
+    >
+      {filteredNavItems.map((item) => {
+        const Icon = item.icon
+        const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`)
+
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={handleClick}
+            className={cn(
+              'group flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors',
+              isActive
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+            )}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            <Icon
+              className={cn(
+                'mr-3 h-5 w-5 flex-shrink-0',
+                isActive
+                  ? 'text-primary-foreground'
+                  : 'text-muted-foreground group-hover:text-accent-foreground'
+              )}
+            />
+            {item.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,198 @@
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { Check, ChevronRight, Circle } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+}


### PR DESCRIPTION
## 概要
共通ヘッダー、ナビゲーション、レイアウトコンポーネントを実装しました。

## 実装内容

### 共通レイアウトコンポーネント

#### ヘッダー (`src/components/layout/header.tsx`)
- ロゴ表示（ダッシュボードへのリンク）
- ユーザーアバター（名前の頭文字を表示）
- ドロップダウンメニュー
  - ユーザー名、メールアドレス、ロール表示
  - プロフィールリンク
  - ログアウトボタン
- レスポンシブ対応（モバイル: ハンバーガーメニューボタン）

#### ナビゲーション (`src/components/layout/navigation.tsx`)
- メニュー項目
  - ダッシュボード
  - 日報（一覧・作成）
  - 顧客（一覧・登録）
  - ユーザー管理（上長のみ表示）
- ロールベースの表示制御
- アクティブページのハイライト
- モバイル/デスクトップ対応

#### メインレイアウト (`src/components/layout/main-layout.tsx`)
- ヘッダー + ナビゲーション + コンテンツエリアの統合
- レスポンシブデザイン
  - デスクトップ: 固定サイドバー
  - モバイル: オーバーレイメニュー
- モバイルメニューの開閉機能

### UIコンポーネント（shadcn/ui）
- **dropdown-menu** - ユーザーメニュー用
- **avatar** - ユーザーアバター表示用

### テスト
- 全41テストがパス ✅
- テストファイル：
  - `src/components/layout/__tests__/header.test.tsx` (10テスト)
  - `src/components/layout/__tests__/navigation.test.tsx` (14テスト)
  - `src/components/layout/__tests__/main-layout.test.tsx` (17テスト)

## 受け入れ基準
- ✅ ヘッダーにユーザー名が表示される
- ✅ ドロップダウンメニューからログアウトできる
- ✅ 営業ユーザーはユーザー管理メニューが表示されない
- ✅ 上長ユーザーはすべてのメニューが表示される
- ✅ スマートフォンでハンバーガーメニューが表示される

## 依存Issue
- #14 (shadcn/ui セットアップ)
- #15 (認証状態管理) - **このPRはIssue #15に依存しています**

## 技術的詳細
- TypeScriptで型安全な実装
- useAuth()フックで認証状態を取得
- Tailwind CSSでレスポンシブデザイン
- アクセシビリティを考慮（ARIA属性、キーボード操作）

## テスト結果
```
✓ src/components/layout/__tests__/header.test.tsx (10 tests)
✓ src/components/layout/__tests__/navigation.test.tsx (14 tests)
✓ src/components/layout/__tests__/main-layout.test.tsx (17 tests)

Test Files  3 passed (3)
Tests  41 passed (41)
```

## 新規パッケージ
- `@radix-ui/react-avatar` - アバターコンポーネント
- `@radix-ui/react-dropdown-menu` - ドロップダウンメニュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)